### PR TITLE
Fix for isbot

### DIFF
--- a/app/entry.server.jsx
+++ b/app/entry.server.jsx
@@ -2,7 +2,7 @@ import { PassThrough } from "stream";
 import { renderToPipeableStream } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
 import { createReadableStreamFromReadable } from "@remix-run/node";
-import { sbot } from "isbot";
+import { isbot } from "isbot";
 import { addDocumentResponseHeaders } from "./shopify.server";
 
 const ABORT_DELAY = 5000;

--- a/app/entry.server.jsx
+++ b/app/entry.server.jsx
@@ -2,7 +2,7 @@ import { PassThrough } from "stream";
 import { renderToPipeableStream } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
 import { createReadableStreamFromReadable } from "@remix-run/node";
-import isbot from "isbot";
+import { sbot } from "isbot";
 import { addDocumentResponseHeaders } from "./shopify.server";
 
 const ABORT_DELAY = 5000;
@@ -14,9 +14,8 @@ export default async function handleRequest(
   remixContext
 ) {
   addDocumentResponseHeaders(request, responseHeaders);
-  const callbackName = isbot(request.headers.get("user-agent"))
-    ? "onAllReady"
-    : "onShellReady";
+  const userAgent = request.headers.get("user-agent");
+  const callbackName = isbot(userAgent ?? "") ? "onAllReady" : "onShellReady";
 
   return new Promise((resolve, reject) => {
     const { pipe, abort } = renderToPipeableStream(

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@shopify/shopify-app-remix": "^2.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^2.0.0",
     "cross-env": "^7.0.3",
-    "isbot": "latest",
+    "isbot": "^4.1.0",
     "prisma": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixing [broken GitHub workflow](https://github.com/Shopify/shopify-app-template-remix/actions/runs/7391569215)

Previously, `isbot()` accepted `string | null`. Now, it only accepts a `string`.

### WHAT is this pull request doing?

Providing a default empty string as a fallback for `request.headers.get("user-agent")`
